### PR TITLE
pom upgrade + logging enhancement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
 
         <dependency>
             <groupId>log4j</groupId>
+            <artifactId>apache-log4j-extras</artifactId>
+            <version>1.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.0-beta-3</version>
+                <version>3.0</version>
             </plugin>
 
             <plugin>
@@ -193,10 +193,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
+                <version>2.11</version>
+<!--                <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                </configuration>
+                </configuration>-->
             </plugin>
         </plugins>
     </build>

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="true">
     
     <appender name="appender-stdout" class="org.apache.log4j.ConsoleAppender">
         <param name="Target" value="System.out"/>
@@ -8,13 +8,28 @@
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" 
                    value="%7p %d{yyyy-MM-dd@kk:mm:ss:SSS} - %C{1}.%M:%L %m%n" />
-<!--              value="%d{HH:mm:ss,SSS} %5p [%-20c{1}] %m%n"/>-->
-
         </layout>
     </appender>
+
+    <appender name="appender-HDFS-NFS" 
+              class="org.apache.log4j.rolling.RollingFileAppender">
+<!--        <param name="DatePattern" value="'.'yyyy-MM-dd"/>-->
+<!--        <param name="encoding" value="UTF-8" />-->
+<!--        <param name="Append" value="true"/>-->
+<!--        <param name="file" value="${java.io.tmpdir}/hdfsNFS-%d{yyyy-MM-dd}.log"/>-->
+<!--        <param name="MaxBackupIndex" value="5"/>-->
+        <rollingPolicy class="org.apache.log4j.rolling.TimeBasedRollingPolicy">
+            <param name="FileNamePattern" value="${java.io.tmpdir}/hdfsNFS-%d{yyyy-MM-dd}.log" />
+        </rollingPolicy>
+        <layout class="org.apache.log4j.PatternLayout"> 
+            <param name="ConversionPattern" 
+                   value="%7p %d{yyyy-MM-dd@kk:mm:ss:SSS} - %C{1}.%M:%L %m%n" />
+        </layout> 
+    </appender> 
     
     <logger name="com.cloudera.hadoop.hdfs.nfs" additivity="false">
         <priority value="DEBUG" />
+        <appender-ref ref="appender-HDFS-NFS" />
         <appender-ref ref="appender-stdout" />
     </logger>
 


### PR DESCRIPTION
upgraded the pom.xml to use the current released site plugin 3.0 (was SNAPSHOT)
added logging extras from log4j for the rolling date based file appender
updated log4j output to 1. goto the console so its easier to debug in the IDE 2. go to ${java.io.tmpdir}/hdfsNFS-%d{yyyy-MM-dd}.log 
